### PR TITLE
Added a annotation support to use default arguments.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
         exclude(module = "spring-jcl")
         exclude(module = "spring-tx")
     }
-    implementation("com.github.ProjectMapK:Shared:0.6")
+    api("com.github.ProjectMapK:Shared:0.7")
 
     // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter
     testImplementation(group = "org.junit.jupiter", name = "junit-jupiter", version = "5.6.0") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.mapk"
-version = "0.1"
+version = "0.2"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/kotlin/com/mapk/krowmapper/KRowMapper.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/KRowMapper.kt
@@ -2,6 +2,7 @@ package com.mapk.krowmapper
 
 import com.mapk.core.EnumMapper
 import com.mapk.core.KFunctionForCall
+import com.mapk.core.isUseDefaultArgument
 import com.mapk.core.toKConstructor
 import java.sql.ResultSet
 import kotlin.reflect.KClass
@@ -22,7 +23,7 @@ class KRowMapper<T : Any> private constructor(
     )
 
     private val parameters: List<ParameterForMap<*>> = function.parameters
-        .filter { it.kind != KParameter.Kind.INSTANCE }
+        .filter { it.kind != KParameter.Kind.INSTANCE && !it.isUseDefaultArgument() }
         .map { ParameterForMap.newInstance(it, propertyNameConverter) }
 
     override fun mapRow(rs: ResultSet, rowNum: Int): T {

--- a/src/test/kotlin/com/mapk/krowmapper/DefaultValueTest.kt
+++ b/src/test/kotlin/com/mapk/krowmapper/DefaultValueTest.kt
@@ -1,0 +1,33 @@
+package com.mapk.krowmapper
+
+import com.google.common.base.CaseFormat
+import com.mapk.annotations.KUseDefaultArgument
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.sql.ResultSet
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class DefaultValueTest {
+    data class Dst(val fooId: Int, @param:KUseDefaultArgument val barValue: String = "default")
+
+    private fun camelToSnake(camel: String): String = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, camel)
+
+    @Test
+    @DisplayName("デフォルト値を用いたマッピングテスト")
+    fun test() {
+        val resultSet = mockk<ResultSet>()
+        every { resultSet.getObject("foo_id", any<Class<*>>()) } returns 1
+        every { resultSet.getObject("bar_value", any<Class<*>>()) } returns "From result set."
+
+        val result = KRowMapper(::Dst, this::camelToSnake).mapRow(resultSet, 0)
+
+        Assertions.assertEquals(1, result.fooId)
+        Assertions.assertEquals("default", result.barValue)
+
+        verify(exactly = 1) { resultSet.getObject("foo_id", Int::class.java) }
+        verify(exactly = 0) { resultSet.getObject("bar_value", String::class.java) }
+    }
+}


### PR DESCRIPTION
# 機能追加
- デフォルト引数を用いる（= マッピング対象にしない）機能を追加

# 不具合修正
- `shared`を`api`で指定するように修正
  - `implementation`で指定していたため、ライブラリ利用時に`shared`が利用できなくなっていた