### PR TITLE
Add annotation that means "Use Non Null argument".

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.mapk"
-version = "0.3"
+version = "0.4"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,8 @@ dependencies {
 
     // テスト時には無いと困るため、別口でimplementation
     testImplementation(group = "org.springframework", name = "spring-jdbc", version = "5.2.4.RELEASE")
+    // https://mvnrepository.com/artifact/com.h2database/h2
+    testImplementation(group = "com.h2database", name = "h2", version = "1.4.200")
 
     // 現状プロパティ名の変換はテストでしか使っていないのでtestImplementation
     // https://mvnrepository.com/artifact/com.google.guava/guava

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
         exclude(module = "spring-jcl")
         exclude(module = "spring-tx")
     }
-    api("com.github.ProjectMapK:Shared:0.7")
+    api("com.github.ProjectMapK:Shared:0.8")
 
     // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter
     testImplementation(group = "org.junit.jupiter", name = "junit-jupiter", version = "5.6.0") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,13 +30,13 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation(kotlin("reflect"))
+    api("com.github.ProjectMapK:Shared:0.8")
     // 使うのはRowMapperのみなため他はexclude、またバージョンそのものは使う相手に合わせるためcompileOnly
     compileOnly(group = "org.springframework", name = "spring-jdbc", version = "5.2.4.RELEASE") {
         exclude(module = "spring-beans")
         exclude(module = "spring-jcl")
         exclude(module = "spring-tx")
     }
-    api("com.github.ProjectMapK:Shared:0.8")
 
     // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter
     testImplementation(group = "org.junit.jupiter", name = "junit-jupiter", version = "5.6.0") {
@@ -44,11 +44,13 @@ dependencies {
     }
     // https://mvnrepository.com/artifact/io.mockk/mockk
     testImplementation("io.mockk:mockk:1.9.3")
+
+    // テスト時には無いと困るため、別口でimplementation
+    testImplementation(group = "org.springframework", name = "spring-jdbc", version = "5.2.4.RELEASE")
+
     // 現状プロパティ名の変換はテストでしか使っていないのでtestImplementation
     // https://mvnrepository.com/artifact/com.google.guava/guava
     testImplementation(group = "com.google.guava", name = "guava", version = "28.2-jre")
-    // テスト時には無いと困るため、別口でimplementation
-    testImplementation(group = "org.springframework", name = "spring-jdbc", version = "5.2.4.RELEASE")
 }
 
 tasks {

--- a/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
@@ -24,15 +24,7 @@ class ParameterForMap private constructor(
     private val deserializer: KFunction<*>?
 
     init {
-        val deserializers = deserializerFromConstructors(kClazz) +
-                deserializerFromStaticMethods(kClazz) +
-                deserializerFromCompanionObject(kClazz)
-
-        deserializer = when {
-            deserializers.isEmpty() -> null
-            deserializers.size == 1 -> deserializers.single()
-            else -> throw IllegalArgumentException("Find multiple deserializer from ${kClazz.jvmName}")
-        }
+        deserializer = kClazz.getDeserializer()
     }
 
     fun getObject(rs: ResultSet): Any? = when {
@@ -51,6 +43,18 @@ class ParameterForMap private constructor(
                 param.type.classifier as KClass<*>
             )
         }
+    }
+}
+
+private fun <T : Any> KClass<T>.getDeserializer(): KFunction<T>? {
+    val deserializers = deserializerFromConstructors(this) +
+            deserializerFromStaticMethods(this) +
+            deserializerFromCompanionObject(this)
+
+    return when {
+        deserializers.isEmpty() -> null
+        deserializers.size == 1 -> deserializers.single()
+        else -> throw IllegalArgumentException("Find multiple deserializer from $jvmName")
     }
 }
 

--- a/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
@@ -29,11 +29,11 @@ class ParameterForMap private constructor(
             val targetClass = deserializer.parameters.single().type.classifier as KClass<*>
 
             {
-                deserializer.call(it.getObject(name, targetClass.java))
+                deserializer.call(it.getObject(name, targetClass.javaObjectType))
             }
         } else {
             {
-                val clazz = parameterKClazz.java
+                val clazz = parameterKClazz.javaObjectType
 
                 when {
                     clazz.isEnum -> EnumMapper.getEnum(clazz, it.getString(name))

--- a/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
@@ -18,13 +18,13 @@ import kotlin.reflect.jvm.jvmName
 class ParameterForMap private constructor(
     val param: KParameter,
     private val name: String,
-    kClazz: KClass<*>
+    parameterKClazz: KClass<*>
 ) {
-    private val javaClazz: Class<*> = kClazz.java
+    private val javaClazz: Class<*> = parameterKClazz.java
     private val deserializer: KFunction<*>?
 
     init {
-        deserializer = kClazz.getDeserializer()
+        deserializer = parameterKClazz.getDeserializer()
     }
 
     fun getObject(rs: ResultSet): Any? = when {

--- a/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
@@ -25,19 +25,22 @@ class ParameterForMap private constructor(
     init {
         val deserializer = parameterKClazz.getDeserializer()
 
-        objectGetter = if (deserializer != null) {
+        if (deserializer != null) {
             val targetClass = deserializer.parameters.single().type.classifier as KClass<*>
 
-            {
+            objectGetter = {
                 deserializer.call(it.getObject(name, targetClass.javaObjectType))
             }
         } else {
-            {
-                val clazz = parameterKClazz.javaObjectType
+            val clazz = parameterKClazz.javaObjectType
 
-                when {
-                    clazz.isEnum -> EnumMapper.getEnum(clazz, it.getString(name))
-                    else -> it.getObject(name, clazz)
+            objectGetter = if (clazz.isEnum) {
+                {
+                    EnumMapper.getEnum(clazz, it.getString(name))
+                }
+            } else {
+                {
+                    it.getObject(name, clazz)
                 }
             }
         }

--- a/src/test/kotlin/com/mapk/krowmapper/DefaultValueTest.kt
+++ b/src/test/kotlin/com/mapk/krowmapper/DefaultValueTest.kt
@@ -27,7 +27,7 @@ class DefaultValueTest {
         Assertions.assertEquals(1, result.fooId)
         Assertions.assertEquals("default", result.barValue)
 
-        verify(exactly = 1) { resultSet.getObject("foo_id", Int::class.java) }
+        verify(exactly = 1) { resultSet.getObject("foo_id", Integer::class.java) }
         verify(exactly = 0) { resultSet.getObject("bar_value", String::class.java) }
     }
 }

--- a/src/test/kotlin/com/mapk/krowmapper/SimpleMappingTest.kt
+++ b/src/test/kotlin/com/mapk/krowmapper/SimpleMappingTest.kt
@@ -27,7 +27,7 @@ class SimpleMappingTest {
         assertEquals(1, result.fooId)
         assertEquals("str", result.strValue)
 
-        verify(exactly = 1) { resultSet.getObject("foo_id", Int::class.java) }
+        verify(exactly = 1) { resultSet.getObject("foo_id", Integer::class.java) }
         verify(exactly = 1) { resultSet.getObject("str_value", String::class.java) }
     }
 }

--- a/src/test/kotlin/com/mapk/krowmapper/UseDBMappingTest.kt
+++ b/src/test/kotlin/com/mapk/krowmapper/UseDBMappingTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.TestInstance
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert
+import javax.sql.DataSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class UseDBMappingTest {
@@ -38,8 +39,9 @@ class UseDBMappingTest {
 
     @BeforeAll
     fun beforeAll() {
-        val dataSource = JdbcDataSource()
-        dataSource.setUrl("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;INIT=CREATE SCHEMA IF NOT EXISTS APP\\;SET SCHEMA APP;")
+        val dataSource: DataSource = JdbcDataSource().apply {
+            setUrl("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;INIT=CREATE SCHEMA IF NOT EXISTS APP\\;SET SCHEMA APP;")
+        }
 
         jdbcTemplate = JdbcTemplate(dataSource)
 

--- a/src/test/kotlin/com/mapk/krowmapper/UseDBMappingTest.kt
+++ b/src/test/kotlin/com/mapk/krowmapper/UseDBMappingTest.kt
@@ -1,0 +1,69 @@
+package com.mapk.krowmapper
+
+import com.google.common.base.CaseFormat
+import org.h2.jdbcx.JdbcDataSource
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class UseDBMappingTest {
+    enum class FooStatus {
+        active, archive, deleted
+    }
+
+    data class Foo(
+        val fooId: Int,
+        val fooName: String,
+        val fooStatus: FooStatus,
+        val isBar: Boolean,
+        val description: String?
+    )
+
+    data class FooInsert(
+        val fooId: Int,
+        val fooName: String,
+        private val fooStatus: FooStatus,
+        private val isBar: Boolean,
+        val description: String?
+    ) {
+        fun getFooStatus(): String = fooStatus.name
+        fun getIsBar(): String = isBar.toString()
+    }
+
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    @BeforeAll
+    fun beforeAll() {
+        val dataSource = JdbcDataSource()
+        dataSource.setUrl("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;INIT=CREATE SCHEMA IF NOT EXISTS APP\\;SET SCHEMA APP;")
+
+        jdbcTemplate = JdbcTemplate(dataSource)
+
+        jdbcTemplate.execute("""
+            CREATE TABLE IF NOT EXISTS `foo_table` (
+              `foo_id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+              `foo_name` VARCHAR(255) NOT NULL,
+              `foo_status` ENUM('active', 'archive', 'deleted') NOT NULL,
+              `is_bar` ENUM('true', 'false') NOT NULL,
+              `description` VARCHAR(1023) NULL DEFAULT NULL,
+              PRIMARY KEY (`foo_id`)
+            );
+        """.trimIndent())
+
+        val data = FooInsert(10, "Foo", FooStatus.archive, false, null)
+
+        SimpleJdbcInsert(jdbcTemplate).withTableName("foo_table").execute(BeanPropertySqlParameterSource(data))
+    }
+
+    @Test
+    fun test() {
+        val result = jdbcTemplate.query("SELECT * FROM foo_table", KRowMapper(::Foo) {
+            CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, it)
+        })
+        println(result)
+    }
+}


### PR DESCRIPTION
# 機能追加
引数がnullの場合無視することを示すアノテーションを追加した。

- [Release Add annotation that means "Use Non Null argument"\. · ProjectMapK/Shared](https://github.com/ProjectMapK/Shared/releases/tag/0.8)

# 修正
`int`など、`primitive`型は`ResultSet`の実装によって取得できる場合とできない場合が有ったため、`javaObjectType`で取る形に統一した。

# リファクタリング
パラメータの取得方法は`RowMapper`の初期化時点で定まるにも関わらず、マッピングの度に型を確認していたため、初期化時点で取得方法をラムダとして取ることで判定を省略するように修正を行った。

# テストの追加
`H2`を用いたマッピングテストを追加した。