### PR TITLE
Fixed a bug when calling with a large number of arguments.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation(kotlin("reflect"))
-    api("com.github.ProjectMapK:Shared:0.8")
+    api("com.github.ProjectMapK:Shared:0.9")
     // 使うのはRowMapperのみなため他はexclude、またバージョンそのものは使う相手に合わせるためcompileOnly
     compileOnly(group = "org.springframework", name = "spring-jdbc", version = "5.2.4.RELEASE") {
         exclude(module = "spring-beans")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.mapk"
-version = "0.4"
+version = "0.7"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
# 修正
- 33以上の引数で呼び出した場合に正常に呼び出しが行えない不具合の修正
  - JVMの上限まで引数を積んでも動くようになった
  - [Release Fixed a bug when calling with a large number of arguments\. · ProjectMapK/Shared](https://github.com/ProjectMapK/Shared/releases/tag/0.9)