### PR TITLE
Fixing generics and keeping up with Shared updates.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.mapk"
-version = "0.13"
+version = "0.14"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation(kotlin("reflect"))
-    api("com.github.ProjectMapK:Shared:0.15")
+    api("com.github.ProjectMapK:Shared:0.16")
     // 使うのはRowMapperのみなため他はexclude、またバージョンそのものは使う相手に合わせるためcompileOnly
     compileOnly(group = "org.springframework", name = "spring-jdbc", version = "5.2.4.RELEASE") {
         exclude(module = "spring-beans")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
     // https://mvnrepository.com/artifact/io.mockk/mockk
-    testImplementation("io.mockk:mockk:1.9.3")
+    testImplementation("io.mockk:mockk:1.10.0")
 
     // テスト時には無いと困るため、別口でimplementation
     testImplementation(group = "org.springframework", name = "spring-jdbc", version = "5.2.4.RELEASE")

--- a/src/main/kotlin/com/mapk/deserialization/KColumnDeserialize.kt
+++ b/src/main/kotlin/com/mapk/deserialization/KColumnDeserialize.kt
@@ -7,7 +7,7 @@ import kotlin.reflect.KClass
 @MustBeDocumented
 annotation class KColumnDeserializeBy(val deserializer: KClass<out AbstractKColumnDeserializer<*, *, *>>)
 
-abstract class AbstractKColumnDeserializer<A : Annotation, S : Any, D : Any>(protected val annotation: A) {
+abstract class AbstractKColumnDeserializer<A : Annotation, S : Any, D>(protected val annotation: A) {
     abstract val srcClass: Class<S>
     abstract fun deserialize(source: S?): D?
 }

--- a/src/main/kotlin/com/mapk/krowmapper/KRowMapper.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/KRowMapper.kt
@@ -16,7 +16,8 @@ class KRowMapper<T : Any> private constructor(private val function: KFunctionFor
         clazz.toKConstructor(parameterNameConverter)
     )
 
-    private val parameters: List<ParameterForMap> = function.requiredParameters.map { ParameterForMap.newInstance(it) }
+    private val parameters: List<ParameterForMap<*, *>> =
+        function.requiredParameters.map { ParameterForMap.newInstance(it) }
 
     override fun mapRow(rs: ResultSet, rowNum: Int): T {
         val adaptor = function.getArgumentAdaptor()

--- a/src/main/kotlin/com/mapk/krowmapper/KRowMapper.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/KRowMapper.kt
@@ -10,11 +10,11 @@ import org.springframework.jdbc.core.RowMapper
 class KRowMapper<T : Any> private constructor(
     private val function: KFunctionForCall<T>
 ) : RowMapper<T> {
-    constructor(function: KFunction<T>, parameterNameConverter: (String) -> String = { it }) : this(
+    constructor(function: KFunction<T>, parameterNameConverter: ((String) -> String)? = null) : this(
         KFunctionForCall(function, parameterNameConverter)
     )
 
-    constructor(clazz: KClass<T>, parameterNameConverter: (String) -> String = { it }) : this(
+    constructor(clazz: KClass<T>, parameterNameConverter: ((String) -> String)? = null) : this(
         clazz.toKConstructor(parameterNameConverter)
     )
 

--- a/src/main/kotlin/com/mapk/krowmapper/KRowMapper.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/KRowMapper.kt
@@ -7,9 +7,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import org.springframework.jdbc.core.RowMapper
 
-class KRowMapper<T : Any> private constructor(
-    private val function: KFunctionForCall<T>
-) : RowMapper<T> {
+class KRowMapper<T : Any> private constructor(private val function: KFunctionForCall<T>) : RowMapper<T> {
     constructor(function: KFunction<T>, parameterNameConverter: ((String) -> String)? = null) : this(
         KFunctionForCall(function, parameterNameConverter)
     )

--- a/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
@@ -19,10 +19,10 @@ import kotlin.reflect.full.staticFunctions
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.jvmName
 
-internal sealed class ParameterForMap {
+internal sealed class ParameterForMap<S, D> {
     abstract val name: String
-    abstract val clazz: Class<*>
-    abstract fun getObject(rs: ResultSet): Any?
+    abstract val clazz: Class<S>
+    abstract fun getObject(rs: ResultSet): D?
 
     private class Plain(override val name: String, override val clazz: Class<*>) : ParameterForMap() {
         override fun getObject(rs: ResultSet): Any? = rs.getObject(name, clazz)

--- a/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
@@ -23,8 +23,8 @@ internal sealed class ParameterForMap<S, D> {
     abstract val name: String
     abstract fun getObject(rs: ResultSet): D?
 
-    private class Plain(override val name: String, override val clazz: Class<*>) : ParameterForMap() {
-        override fun getObject(rs: ResultSet): Any? = rs.getObject(name, clazz)
+    private class Plain<T>(override val name: String, val requiredClazz: Class<T>) : ParameterForMap<T, T>() {
+        override fun getObject(rs: ResultSet): T? = rs.getObject(name, requiredClazz)
     }
 
     private class Enum(override val name: String, override val clazz: Class<*>) : ParameterForMap() {

--- a/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
@@ -111,5 +111,5 @@ private fun <T : Any> deserializerFromCompanionObject(clazz: KClass<T>): Collect
         functions.map {
             KFunctionWithInstance(it, instance) as KFunction<T>
         }
-    } ?: emptySet()
+    } ?: emptyList()
 }

--- a/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
@@ -45,7 +45,7 @@ internal sealed class ParameterForMap<S, D> {
     }
 
     companion object {
-        fun <T : Any> newInstance(param: ValueParameter<T>): ParameterForMap {
+        fun <T : Any> newInstance(param: ValueParameter<T>): ParameterForMap<*, T> {
             param.getDeserializer()?.let {
                 return Deserializer(param.name, it)
             }

--- a/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
@@ -27,8 +27,8 @@ internal sealed class ParameterForMap<S, D> {
         override fun getObject(rs: ResultSet): T? = rs.getObject(name, requiredClazz)
     }
 
-    private class Enum(override val name: String, override val clazz: Class<*>) : ParameterForMap() {
-        override fun getObject(rs: ResultSet): Any? = EnumMapper.getEnum(clazz, rs.getString(name))
+    private class Enum<D>(override val name: String, val enumClazz: Class<D>) : ParameterForMap<String, D>() {
+        override fun getObject(rs: ResultSet): D? = EnumMapper.getEnum(enumClazz, rs.getString(name))
     }
 
     private class Deserializer(

--- a/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
@@ -21,7 +21,6 @@ import kotlin.reflect.jvm.jvmName
 
 internal sealed class ParameterForMap<S, D> {
     abstract val name: String
-    abstract val clazz: Class<S>
     abstract fun getObject(rs: ResultSet): D?
 
     private class Plain(override val name: String, override val clazz: Class<*>) : ParameterForMap() {

--- a/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
@@ -24,17 +24,11 @@ internal sealed class ParameterForMap {
     abstract val clazz: Class<*>
     abstract fun getObject(rs: ResultSet): Any?
 
-    private class Plain(
-        override val name: String,
-        override val clazz: Class<*>
-    ) : ParameterForMap() {
+    private class Plain(override val name: String, override val clazz: Class<*>) : ParameterForMap() {
         override fun getObject(rs: ResultSet): Any? = rs.getObject(name, clazz)
     }
 
-    private class Enum(
-        override val name: String,
-        override val clazz: Class<*>
-    ) : ParameterForMap() {
+    private class Enum(override val name: String, override val clazz: Class<*>) : ParameterForMap() {
         override fun getObject(rs: ResultSet): Any? = EnumMapper.getEnum(clazz, rs.getString(name))
     }
 

--- a/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
@@ -31,17 +31,17 @@ internal sealed class ParameterForMap<S, D> {
         override fun getObject(rs: ResultSet): D? = EnumMapper.getEnum(enumClazz, rs.getString(name))
     }
 
-    private class Deserializer(
+    private class Deserializer<S : Any, D>(
         override val name: String,
-        override val clazz: Class<*>,
-        private val deserializer: KFunction<*>
-    ) : ParameterForMap() {
+        val srcClazz: Class<S>,
+        private val deserializer: KFunction<D?>
+    ) : ParameterForMap<S, D>() {
         constructor(
             name: String,
-            deserializer: AbstractKColumnDeserializer<*, *, *>
+            deserializer: AbstractKColumnDeserializer<*, S, D>
         ) : this(name, deserializer.srcClass, deserializer::deserialize)
 
-        override fun getObject(rs: ResultSet): Any? = deserializer.call(rs.getObject(name, clazz))
+        override fun getObject(rs: ResultSet): D? = deserializer.call(rs.getObject(name, srcClazz))
     }
 
     companion object {


### PR DESCRIPTION
# ジェネリクスの整理
`ParameterForMap`にジェネリクスを補った。
また、`abstract`プロパティの`clazz: Class<*>`の利用方法に混乱が見られたため、`abstract`プロパティとしては削除した。

# Sharedのアップデート取り込み
`Shared`のアップデートを取り込み処理効率を向上した。
- [Release Fine\-grained optimization\. · ProjectMapK/Shared](https://github.com/ProjectMapK/Shared/releases/tag/0.16)

## parameterNameConverterの取り扱いの修正
`parameterNameConverter`を`nullable`に、またデフォルト引数を`null`に修正した。

# その他
- `MockK`のアップデート
- 一部フォーマット修正
- 無意味に`emptySet`を返していた部分の修正