### PR TITLE
Fix deserializer's nullability.

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -310,11 +310,7 @@ class LocalDateTimeDeserializerImpl(
 
     override val srcClass: Class<String> = String::class.javaObjectType
 
-    override fun deserialize(source: String?): LocalDateTime? {
-        return source?.let {
-            LocalDateTime.parse(it, formatter)
-        }
-    }
+    override fun deserialize(source: String): LocalDateTime = LocalDateTime.parse(source, formatter)
 }
 ```
 
@@ -340,11 +336,7 @@ class LocalDateTimeDeserializerImpl(
 
     override val srcClass: Class<String> = String::class.javaObjectType
 
-    override fun deserialize(source: String?): LocalDateTime? {
-        return source?.let {
-            LocalDateTime.parse(it, formatter)
-        }
-    }
+    override fun deserialize(source: String): LocalDateTime = LocalDateTime.parse(source, formatter)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ Please see [here](https://jitpack.io/#ProjectMapK/KRowMapper/) for the formal in
 **2. add dependency**
 
 ```xml
-	<dependency>
-	    <groupId>com.github.ProjectMapK</groupId>
-	    <artifactId>KRowMapper</artifactId>
-	    <version>Tag</version>
-	</dependency>
+    <dependency>
+        <groupId>com.github.ProjectMapK</groupId>
+        <artifactId>KRowMapper</artifactId>
+        <version>Tag</version>
+    </dependency>
 ```
 
 ## Principle of operation

--- a/src/main/kotlin/com/mapk/deserialization/KColumnDeserialize.kt
+++ b/src/main/kotlin/com/mapk/deserialization/KColumnDeserialize.kt
@@ -9,5 +9,5 @@ annotation class KColumnDeserializeBy(val deserializer: KClass<out AbstractKColu
 
 abstract class AbstractKColumnDeserializer<A : Annotation, S : Any, D>(protected val annotation: A) {
     abstract val srcClass: Class<S>
-    abstract fun deserialize(source: S?): D?
+    abstract fun deserialize(source: S): D?
 }

--- a/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
+++ b/src/main/kotlin/com/mapk/krowmapper/ParameterForMap.kt
@@ -41,7 +41,7 @@ internal sealed class ParameterForMap<S, D> {
             deserializer: AbstractKColumnDeserializer<*, S, D>
         ) : this(name, deserializer.srcClass, deserializer::deserialize)
 
-        override fun getObject(rs: ResultSet): D? = deserializer.call(rs.getObject(name, srcClazz))
+        override fun getObject(rs: ResultSet): D? = rs.getObject(name, srcClazz)?.let { deserializer.call(it) }
     }
 
     companion object {

--- a/src/test/kotlin/com/mapk/krowmapper/DeserializerTest.kt
+++ b/src/test/kotlin/com/mapk/krowmapper/DeserializerTest.kt
@@ -8,6 +8,7 @@ import java.sql.ResultSet
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
@@ -29,10 +30,11 @@ class DeserializerTest {
         override fun deserialize(source: String): LocalDateTime = LocalDateTime.parse(source, formatter)
     }
 
-    data class Dst(@LocalDateTimeDeserializer val dateTime: LocalDateTime)
+    data class Dst(@LocalDateTimeDeserializer val dateTime: LocalDateTime?)
 
     @Test
-    fun test() {
+    @DisplayName("正常に変換した場合")
+    fun isCollect() {
         val resultSet = mockk<ResultSet>()
         every { resultSet.getObject("dateTime", any<Class<*>>()) } returns "2020-02-01T01:23:45"
 
@@ -42,5 +44,17 @@ class DeserializerTest {
             LocalDateTime.parse("2020-02-01T01:23:45", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")),
             result.dateTime
         )
+    }
+
+    @Test
+    @DisplayName("取得結果がnullだった場合")
+    fun isNull() {
+        val resultSet = mockk<ResultSet> {
+            every { getObject("dateTime", any<Class<*>>()) } returns null
+        }
+
+        val result = KRowMapper(::Dst).mapRow(resultSet, 0)
+
+        assertNull(result.dateTime)
     }
 }

--- a/src/test/kotlin/com/mapk/krowmapper/DeserializerTest.kt
+++ b/src/test/kotlin/com/mapk/krowmapper/DeserializerTest.kt
@@ -32,13 +32,16 @@ class DeserializerTest {
 
     data class Dst(@LocalDateTimeDeserializer val dateTime: LocalDateTime?)
 
+    val mapper = KRowMapper(::Dst)
+
     @Test
     @DisplayName("正常に変換した場合")
     fun isCollect() {
-        val resultSet = mockk<ResultSet>()
-        every { resultSet.getObject("dateTime", any<Class<*>>()) } returns "2020-02-01T01:23:45"
+        val resultSet = mockk<ResultSet> {
+            every { getObject("dateTime", any<Class<*>>()) } returns "2020-02-01T01:23:45"
+        }
 
-        val result = KRowMapper(::Dst).mapRow(resultSet, 0)
+        val result = mapper.mapRow(resultSet, 0)
 
         assertEquals(
             LocalDateTime.parse("2020-02-01T01:23:45", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")),
@@ -53,7 +56,7 @@ class DeserializerTest {
             every { getObject("dateTime", any<Class<*>>()) } returns null
         }
 
-        val result = KRowMapper(::Dst).mapRow(resultSet, 0)
+        val result = mapper.mapRow(resultSet, 0)
 
         assertNull(result.dateTime)
     }

--- a/src/test/kotlin/com/mapk/krowmapper/DeserializerTest.kt
+++ b/src/test/kotlin/com/mapk/krowmapper/DeserializerTest.kt
@@ -26,11 +26,7 @@ class DeserializerTest {
 
         override val srcClass: Class<String> = String::class.javaObjectType
 
-        override fun deserialize(source: String?): LocalDateTime? {
-            return source?.let {
-                LocalDateTime.parse(it, formatter)
-            }
-        }
+        override fun deserialize(source: String): LocalDateTime = LocalDateTime.parse(source, formatter)
     }
 
     data class Dst(@LocalDateTimeDeserializer val dateTime: LocalDateTime)


### PR DESCRIPTION
# 変更の前提
## ProjectMapKにおける変換処理の方針について
`ProjectMapK`内では、変換処理の引数を`non-null`で扱う。
理由は、変換処理は共通で使い回されるものである一方、入力が`null`だった場合に設定する値というのは関数ごとに決定されるべきと考えられるためである。

### 補足: 「nullならデフォルト値」の実現方法
「`null`ならデフォルト値」の実現は以下2つの方法が考えられる。

1. 関数側で`null`時の取り扱いを記述する
2. `KParameterRequireNonNull`アノテーションとデフォルト引数を組み合わせる

# 破壊的変更
`ResultSet`からの取得結果が`null`の場合変換処理を動かさないように修正を行った。
また、この変更によって変換処理は値が`null`では発生しなくなるため、`AbstractKColumnDeserializer`の`deserialize`関数のパラメータを`non-null`要求に修正した。

# その他
変更に合わせテストの修正を行い、テストパターンも追加を行った。
また、変更に合わせ`README`も更新を行った。